### PR TITLE
Updated create-webhooks.sh to use singular token, and added new create-webhooks.sh workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,9 +31,10 @@ jobs:
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         with:
           skip-token-revoke: 'true'
-          app-id: ${{ secrets.github_app_id }}
-          private-key: ${{ secrets.github_app_private_key }}
+          app-id: ${{ vars.LAA_JAVA_SERVICE_DEPLOYER_APP_ID }}
+          private-key: ${{ secrets.LAA_JAVA_SERVICE_DEPLOYER_KEY }}
           owner: 'ministryofjustice'
+          permission-actions: write
       - name: Authenticate to the cluster
         uses: ./.github/actions/authenticate-cluster
         with:
@@ -46,6 +47,6 @@ jobs:
       - name: Apply webhooks
         env:
           NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
-          GH_ACCESS_TOKEN: ${{ steps.get_workflow_token.outputs.token }}
+          GH_TOKEN: ${{ steps.get_workflow_token.outputs.token }}
         run: ./create-webhooks.sh
         working-directory: ./seed

--- a/.github/workflows/recreate-webhooks.yml
+++ b/.github/workflows/recreate-webhooks.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   apply_webhooks:
-    #if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/recreate-webhooks.yml
+++ b/.github/workflows/recreate-webhooks.yml
@@ -7,9 +7,6 @@ on:
   schedule:
     # At minute 0 and 30 past every hour from 8 through 20
     - cron: 0,30 8-20 * * *
-  push:
-    branches:
-      - create-dynamic-token
 
 
 jobs:

--- a/.github/workflows/recreate-webhooks.yml
+++ b/.github/workflows/recreate-webhooks.yml
@@ -1,31 +1,20 @@
-name: Deploy
+name: Recreate webhooks
 
-on: [push]
+# This recreates webhooks for the Pact Broker service twice an hour using a generated token. This
+# token will only be valid for 1 hour so this runs every 30 minutes.
+
+on:
+  schedule:
+    # At minute 0 and 30 past every hour from 8 through 20
+    - cron: 0,30 8-20 * * *
 
 jobs:
-  deploy:
-    if: ${{ github.ref == 'refs/heads/main' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Authenticate to the cluster
-        uses: ./.github/actions/authenticate-cluster
-        with:
-          kube_cluster: ${{ secrets.KUBE_CLUSTER }}
-          kube_cert: ${{ secrets.KUBE_CERT }}
-          kube_token: ${{ secrets.KUBE_TOKEN }}
-          kube_namespace: ${{ secrets.KUBE_NAMESPACE }}
-      - name: Make deploy.sh executable
-        run: chmod +x ./deploy.sh
-      - name: Deploy
-        run: ./deploy.sh
   apply_webhooks:
     if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
       - name: Get app token
         id: get_workflow_token
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0

--- a/.github/workflows/recreate-webhooks.yml
+++ b/.github/workflows/recreate-webhooks.yml
@@ -7,10 +7,14 @@ on:
   schedule:
     # At minute 0 and 30 past every hour from 8 through 20
     - cron: 0,30 8-20 * * *
+  push:
+    branches:
+      - create-dynamic-token
+
 
 jobs:
   apply_webhooks:
-    if: ${{ github.ref == 'refs/heads/main' }}
+    #if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -20,9 +24,10 @@ jobs:
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         with:
           skip-token-revoke: 'true'
-          app-id: ${{ secrets.github_app_id }}
-          private-key: ${{ secrets.github_app_private_key }}
+          app-id: ${{ vars.LAA_JAVA_SERVICE_DEPLOYER_APP_ID }}
+          private-key: ${{ secrets.LAA_JAVA_SERVICE_DEPLOYER_KEY }}
           owner: 'ministryofjustice'
+          permission-actions: write
       - name: Authenticate to the cluster
         uses: ./.github/actions/authenticate-cluster
         with:
@@ -35,6 +40,6 @@ jobs:
       - name: Apply webhooks
         env:
           NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
-          GH_ACCESS_TOKEN: ${{ steps.get_workflow_token.outputs.token }}
+          GH_TOKEN: ${{ steps.get_workflow_token.outputs.token }}
         run: ./create-webhooks.sh
         working-directory: ./seed

--- a/seed/create-webhooks.sh
+++ b/seed/create-webhooks.sh
@@ -3,9 +3,9 @@
 PACT_BROKER_USERNAME=$(kubectl get secret laa-data-pact-broker-secrets -n $NAMESPACE -o jsonpath='{.data.PACT_BROKER_BASIC_AUTH_USERNAME}'  | base64 --decode)
 PACT_BROKER_PASSWORD=$(kubectl get secret laa-data-pact-broker-secrets -n $NAMESPACE -o jsonpath='{.data.PACT_BROKER_BASIC_AUTH_PASSWORD}'  | base64 --decode)
 
-if [ "GH_PAT_ACCESS_TOKEN" = "" ] || [ "GH_CLAIMS_PAT_ACCESS_TOKEN" = "" ] || [ "$PACT_BROKER_USERNAME" = "" ] || [ "$PACT_BROKER_PASSWORD" = "" ]; then
+if [ "GH_ACCESS_TOKEN" = "" ] || [ "$PACT_BROKER_USERNAME" = "" ] || [ "$PACT_BROKER_PASSWORD" = "" ]; then
   echo "One or more environment variables are missing. Usage:"
-  echo "GH_PAT_ACCESS_TOKEN=token GH_CLAIMS_PAT_ACCESS_TOKEN=token PACT_BROKER_USERNAME=user PACT_BROKER_PASSWORD=password $0"
+  echo "GH_ACCESS_TOKEN=token PACT_BROKER_USERNAME=user PACT_BROKER_PASSWORD=password $0"
   exit 1
 fi
 
@@ -13,9 +13,7 @@ function upsert_webhook() {
   local file="$1"
   local webhookID="$2"
   echo "✨ applying $file..."
-  sed -e "s/\${GH_PAT_ACCESS_TOKEN}/$GH_PAT_ACCESS_TOKEN/g" \
-      -e "s/\${GH_CLAIMS_PAT_ACCESS_TOKEN}/$GH_CLAIMS_PAT_ACCESS_TOKEN/g" \
-      "$file" |
+  sed "s/\${GH_ACCESS_TOKEN}/GH_ACCESS_TOKEN/" "$file" |
     curl -X PUT \
       "https://laa-data-pact-broker.apps.live.cloud-platform.service.justice.gov.uk/webhooks/$webhookID" \
       --user "$PACT_BROKER_USERNAME:$PACT_BROKER_PASSWORD" \

--- a/seed/create-webhooks.sh
+++ b/seed/create-webhooks.sh
@@ -3,9 +3,9 @@
 PACT_BROKER_USERNAME=$(kubectl get secret laa-data-pact-broker-secrets -n $NAMESPACE -o jsonpath='{.data.PACT_BROKER_BASIC_AUTH_USERNAME}'  | base64 --decode)
 PACT_BROKER_PASSWORD=$(kubectl get secret laa-data-pact-broker-secrets -n $NAMESPACE -o jsonpath='{.data.PACT_BROKER_BASIC_AUTH_PASSWORD}'  | base64 --decode)
 
-if [ "GH_ACCESS_TOKEN" = "" ] || [ "$PACT_BROKER_USERNAME" = "" ] || [ "$PACT_BROKER_PASSWORD" = "" ]; then
+if [ "GH_TOKEN" = "" ] || [ "$PACT_BROKER_USERNAME" = "" ] || [ "$PACT_BROKER_PASSWORD" = "" ]; then
   echo "One or more environment variables are missing. Usage:"
-  echo "GH_ACCESS_TOKEN=token PACT_BROKER_USERNAME=user PACT_BROKER_PASSWORD=password $0"
+  echo "GH_TOKEN=token PACT_BROKER_USERNAME=user PACT_BROKER_PASSWORD=password $0"
   exit 1
 fi
 
@@ -13,7 +13,7 @@ function upsert_webhook() {
   local file="$1"
   local webhookID="$2"
   echo "✨ applying $file..."
-  sed "s/\${GH_ACCESS_TOKEN}/GH_ACCESS_TOKEN/" "$file" |
+  sed "s/\${GH_TOKEN}/$GH_TOKEN/" "$file" |
     curl -X PUT \
       "https://laa-data-pact-broker.apps.live.cloud-platform.service.justice.gov.uk/webhooks/$webhookID" \
       --user "$PACT_BROKER_USERNAME:$PACT_BROKER_PASSWORD" \

--- a/seed/webhook-laa-data-claims-api.json
+++ b/seed/webhook-laa-data-claims-api.json
@@ -14,7 +14,7 @@
     "headers": {
       "Accept": "application/vnd.github.v3+json",
       "Content-Type": "application/json",
-      "Authorization": "Bearer ${GH_CLAIMS_PAT_ACCESS_TOKEN}"
+      "Authorization": "Bearer ${GH_TOKEN}"
     },
     "body": {
       "ref": "main",

--- a/seed/webhook-laa-data-provider-data-service.json
+++ b/seed/webhook-laa-data-provider-data-service.json
@@ -14,7 +14,7 @@
     "headers": {
       "Accept": "application/vnd.github.v3+json",
       "Content-Type": "application/json",
-      "Authorization": "Bearer ${GH_PAT_ACCESS_TOKEN}"
+      "Authorization": "Bearer ${GH_TOKEN}"
     },
     "body": {
       "ref": "main",


### PR DESCRIPTION


Refs: [DSTEW-1133](https://dsdmoj.atlassian.net/browse/DSTEW-1133) Switch to use service account for web hook creation in the Pact Broker

## Checklist

- [ ] GitHub should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
