### PR TITLE
Change cron schedule to start at 7 AM

### DIFF
--- a/.github/workflows/recreate-webhooks.yml
+++ b/.github/workflows/recreate-webhooks.yml
@@ -6,7 +6,7 @@ name: Recreate webhooks
 on:
   schedule:
     # At minute 0 and 30 past every hour from 8 through 20
-    - cron: 0,30 8-20 * * *
+    - cron: 0,30 7-20 * * *
 
 
 jobs:


### PR DESCRIPTION
Currently the CRON job is setup to run from 8am till 8pm. However due to BST, this actually runs at 9am till 9pm. This morning start is a bit on the later side so this pushes it back an hour.
