### PR TITLE
Security: Pin checkout github action to a specific commit

### DIFF
--- a/.github/workflows/recreate-webhooks.yml
+++ b/.github/workflows/recreate-webhooks.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Get app token
         id: get_workflow_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0


### PR DESCRIPTION
## What
Pin checkout github action to a specific commit

Inline with other `actions/checkout` usage in this repository,
and inline with guardrails.

## Checklist

- [ ] GitHub should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
