### PR TITLE
Fix: Handle deprecated argument name on GHA

### DIFF
--- a/.github/workflows/recreate-webhooks.yml
+++ b/.github/workflows/recreate-webhooks.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           skip-token-revoke: 'true'
-          app-id: ${{ vars.LAA_JAVA_SERVICE_DEPLOYER_APP_ID }}
+          client-id: ${{ vars.LAA_JAVA_SERVICE_DEPLOYER_APP_ID }}
           private-key: ${{ secrets.LAA_JAVA_SERVICE_DEPLOYER_KEY }}
           owner: 'ministryofjustice'
           permission-actions: write


### PR DESCRIPTION
## What
Handle deprecated argument name on GHA

Currently get a deprecation warning when using the app-id argument
name on the create-github-app-token action. The correct argument name is client-id.

```
apply_webhooks
  Input 'app-id' has been deprecated with message: Use 'client-id' instead.
```
This commit updates the workflow to use the correct argument name.

## Checklist

- [ ] GitHub should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
