### PR TITLE
Improvment: Enable manual trigger of recreate-webhooks workflow

### DIFF
--- a/.github/workflows/recreate-webhooks.yml
+++ b/.github/workflows/recreate-webhooks.yml
@@ -4,6 +4,7 @@ name: Recreate webhooks
 # token will only be valid for 1 hour so this runs every 30 minutes.
 
 on:
+  workflow_dispatch:
   schedule:
     # At minute 7 and 37 past every hour from 6 through 21
     - cron: "7,37 6-21 * * *"


### PR DESCRIPTION
## What
Enable manual triggering of recreate-webhooks workflow

Because GHA action schedules are not gauranteed and if the
schedule overshoots an hour then the token will expire and
pact flows on onboarded repos could fail.

This would allow a user to manually trigger the workflow to
recreate webhooks if this is blocking a team.

## Checklist

- [ ] GitHub should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
